### PR TITLE
test scripts for btc transaction validate

### DIFF
--- a/contract/bridge/README.md
+++ b/contract/bridge/README.md
@@ -1,0 +1,7 @@
+# ONEBTC
+
+## Compilation
+`truffle compile`
+
+## Testing
+`truffle test`

--- a/contract/bridge/contracts/Request.sol
+++ b/contract/bridge/contracts/Request.sol
@@ -31,7 +31,7 @@ struct S_RedeemRequest{
     uint256 premium_one;
     address requester;
     address btc_address;
-    /// The latest Bitcoin height as reported by the BTC-Relay at time of opening.
+    // The latest Bitcoin height as reported by the BTC-Relay at time of opening.
     uint256 btc_height;
     RequestStatus status;
 }

--- a/contract/bridge/contracts/TransactionUtils.sol
+++ b/contract/bridge/contracts/TransactionUtils.sol
@@ -18,7 +18,7 @@ library TransactionUtils {
         uint32 locktime;
     }
 
-    function extractTx(bytes memory raw_tx) internal returns(Transaction memory) {
+    function extractTx(bytes memory raw_tx) internal pure returns(Transaction memory) {
         uint length = raw_tx.length;
         uint pos = 4; // skip version
 

--- a/contract/bridge/contracts/TxValidate.sol
+++ b/contract/bridge/contracts/TxValidate.sol
@@ -28,9 +28,9 @@ library TxValidate {
                 }
             }
         }
-        require(btc_address == recipient_btc_address, "wrong btc_address");
-        require(OP_RETURN_DATA.length > 0, "no op_return");
-        op_return = OP_RETURN_DATA.toUint(0);
+        require(btc_address == recipient_btc_address, "InvalidRecipient");
+        require(OP_RETURN_DATA.length > 0, "NoOpRetrun");
+        op_return = OP_RETURN_DATA.bytesToUint();
     }
     function validate_transaction(bytes memory tx_vout, uint256 minimum_btc, address recipient_btc_address, uint256 op_return_id) internal pure returns(uint256) {
         (uint256 extr_payment_value, uint256 extr_op_return) = extract_payment_value_and_op_return(tx_vout, recipient_btc_address);

--- a/contract/bridge/contracts/mock/RelayMock.sol
+++ b/contract/bridge/contracts/mock/RelayMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.6.12;
 
-import {IRelay} from "./IRelay.sol";
+import {IRelay} from "../IRelay.sol";
 
 contract RelayMock is IRelay {
     function submitBlockHeader(bytes calldata header) external override {}

--- a/contract/bridge/contracts/mock/TransactionUtilsMock.sol
+++ b/contract/bridge/contracts/mock/TransactionUtilsMock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
+
+import {TransactionUtils} from  '../TransactionUtils.sol';
+
+contract TransactionUtilsMock {
+    function extractTx(bytes memory raw_tx) public pure returns(TransactionUtils.Transaction memory) {
+        return TransactionUtils.extractTx(raw_tx);
+    }
+}

--- a/contract/bridge/contracts/mock/TxValidateMock.sol
+++ b/contract/bridge/contracts/mock/TxValidateMock.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+import {TxValidate} from '../TxValidate.sol';
+
+contract TxValidateMock {
+    function validate_transaction(bytes memory tx_vout, uint256 minimum_btc, address recipient_btc_address, uint256 op_return_id) public pure returns(uint256) {
+        return TxValidate.validate_transaction(tx_vout, minimum_btc, recipient_btc_address, op_return_id);
+    }
+}

--- a/contract/bridge/package.json
+++ b/contract/bridge/package.json
@@ -1,6 +1,11 @@
 {
   "dependencies": {
     "@interlay/bitcoin-spv-sol": "^3.2.2",
-    "@openzeppelin/contracts": "3.1.0"
+    "@openzeppelin/contracts": "3.1.0",
+    "@openzeppelin/test-helpers": "^0.5.11",
+    "bitcoinjs-lib": "^5.2.0"
+  },
+  "devDependencies": {
+    "ethereum-waffle": "^3.3.0"
   }
 }

--- a/contract/bridge/test/TxValidate.test.js
+++ b/contract/bridge/test/TxValidate.test.js
@@ -1,0 +1,77 @@
+const TxUtils = artifacts.require("TransactionUtilsMock");
+const TxValidate = artifacts.require("TxValidateMock");
+
+const bitcoin = require('bitcoinjs-lib');
+const { expectRevert } = require("@openzeppelin/test-helpers");
+const { issue_tx_mock } = require('./mock/btcTxMock');
+
+contract("transaction parse test", accounts => {
+    it("extractTx and validate_txout", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(request_id, receiver_address, request_amount);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x'+bitcoin.address.fromBase58Check(receiver_address).hash.toString('hex');
+        const amount = await txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id);
+        assert.equal(Number(amount), request_amount);
+    });
+    it("validate_txout with wrong request_id", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(request_id, receiver_address, request_amount);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x'+bitcoin.address.fromBase58Check(receiver_address).hash.toString('hex');
+        await expectRevert(txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id+1), "InvalidOpReturn");
+    });
+    it("validate_txout with less amount", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(request_id, receiver_address, request_amount-1);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x'+bitcoin.address.fromBase58Check(receiver_address).hash.toString('hex');
+        await expectRevert(txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id), "InsufficientValue");
+    });
+    it("validate_txout with more amount", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(request_id, receiver_address, request_amount+10);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x'+bitcoin.address.fromBase58Check(receiver_address).hash.toString('hex');
+        const amount = await txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id);
+        assert.equal(Number(amount), request_amount+10);
+    });
+    it("validate_txout with wrong receiver", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(request_id, receiver_address, request_amount+10);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x1111111111111111111111111111111111111111';
+        await expectRevert(txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id), "InvalidRecipient");
+    });
+    it("validate_txout without request_id", async () => {
+        const txUtils = await TxUtils.new();
+        const txValidate = await TxValidate.new();
+        const receiver_address = '12L1QTVLowqsRUNht35RyBE3RZzmCZzYF3';
+        const request_id = 123;
+        const request_amount = 2.5e8;
+        const tx_mock = issue_tx_mock(undefined, receiver_address, request_amount+10);
+        const parsed_tx = await txUtils.extractTx(tx_mock.toBuffer());
+        const receiver_address_hex = '0x'+bitcoin.address.fromBase58Check(receiver_address).hash.toString('hex');
+        await expectRevert(txValidate.validate_transaction(parsed_tx.vouts, request_amount, receiver_address_hex, request_id), "NoOpRetrun");
+    });
+});

--- a/contract/bridge/test/mock/btcTxMock.js
+++ b/contract/bridge/test/mock/btcTxMock.js
@@ -1,0 +1,28 @@
+const bitcoin = require('bitcoinjs-lib')
+
+//const ecp = bitcoin.ECPair.makeRandom();
+//const p2pkh = bitcoin.payments.p2pkh({pubkey:ecp.publicKey})
+//console.log(tx)
+
+const Number2Buffer = num=>{ // bigendia
+    let str = num.toString(16);
+    if(str.length&1) str='0'+str;
+    return Buffer.from(str, 'hex');
+}
+
+function issue_tx_mock(issue_id, vault_address, issue_value) {
+    const valut_script = bitcoin.address.toOutputScript(vault_address);
+    const tx = new bitcoin.Transaction();
+    tx.addInput(Buffer.alloc(32, 1), 0, 4294967295, Buffer.alloc(32));
+    tx.addOutput(valut_script, issue_value)
+    if(issue_id != undefined){
+        const OpData = Number2Buffer(issue_id);
+        const embed = bitcoin.payments.embed({ data: [OpData] });
+        tx.addOutput(embed.output, 0)
+    }
+    return tx;
+}
+
+module.exports = {
+    issue_tx_mock
+}


### PR DESCRIPTION
1. use bytesToUint() to parse op_return
2. tx validate test scripts